### PR TITLE
Add nftContractSearch and transaction hash

### DIFF
--- a/nft.avax.yaml
+++ b/nft.avax.yaml
@@ -1,5 +1,7 @@
 specVersion: 0.0.2
 description: NFT
+features:
+  - fullTextSearch
 schema:
   file: ./schema.graphql
 dataSources:

--- a/nft.fuji.yaml
+++ b/nft.fuji.yaml
@@ -1,5 +1,7 @@
 specVersion: 0.0.2
 description: NFT
+features:
+  - fullTextSearch
 schema:
   file: ./schema.graphql
 dataSources:

--- a/nft.template.yaml
+++ b/nft.template.yaml
@@ -1,5 +1,7 @@
 specVersion: 0.0.2
 description: NFT
+features:
+  - fullTextSearch
 schema:
   file: ./schema.graphql
 dataSources:

--- a/schema.graphql
+++ b/schema.graphql
@@ -23,13 +23,14 @@ type NftContract @entity {
 }
 
 type Transfer @entity {
-  # {contractAddress}_{tokenId}_{from}_{to}_{timestamp}
+  # {contractAddress}_{tokenId}_{from}_{to}_{transactionHash}
   id: ID!
   from: Bytes!
   nft: Nft!
   quantity: BigInt!
   timestamp: BigInt!
   to: Bytes!
+  transactionHash: Bytes!
 }
 
 type Ownership @entity {

--- a/schema.graphql
+++ b/schema.graphql
@@ -1,3 +1,17 @@
+type _Schema_
+  @fulltext(
+    name: "nftSearch"
+    language: en
+    algorithm: rank
+    include: [
+      { entity: "Nft", fields: [{ name: "id" }, { name: "tokenURI" }] }
+      {
+        entity: "NftContract"
+        fields: [{ name: "id" }, { name: "name" }, { name: "symbol" }]
+      }
+    ]
+  )
+
 type Nft @entity {
   # {contractAddress}_{tokenId}
   id: ID!

--- a/schema.graphql
+++ b/schema.graphql
@@ -1,10 +1,9 @@
 type _Schema_
   @fulltext(
-    name: "nftSearch"
+    name: "nftContractSearch"
     language: en
     algorithm: rank
     include: [
-      { entity: "Nft", fields: [{ name: "id" }, { name: "tokenURI" }] }
       {
         entity: "NftContract"
         fields: [{ name: "id" }, { name: "name" }, { name: "symbol" }]

--- a/src/entities/nft.ts
+++ b/src/entities/nft.ts
@@ -1,4 +1,4 @@
-import { Address, BigInt, store } from "@graphprotocol/graph-ts";
+import { Address, BigInt, Bytes, store } from "@graphprotocol/graph-ts";
 import { ERC165 } from "../../generated/ERC721/ERC165";
 import { ERC721 } from "../../generated/ERC721/ERC721";
 import { ERC1155 } from "../../generated/ERC1155/ERC1155";
@@ -26,7 +26,8 @@ export function transferBase(
   toAddress: Address,
   tokenId: BigInt,
   value: BigInt,
-  timestamp: BigInt
+  timestamp: BigInt,
+  transactionHash: Bytes
 ): void {
   let contractAddressHexString = contractAddress.toHexString();
   let nftId = contractAddressHexString + "_" + tokenId.toString();
@@ -137,7 +138,14 @@ export function transferBase(
     }
     nft.save();
 
-    upsertTransfer(nftId, fromAddress, toAddress, value, timestamp);
+    upsertTransfer(
+      nftId,
+      fromAddress,
+      toAddress,
+      value,
+      timestamp,
+      transactionHash
+    );
   }
   nftContract.save();
 }

--- a/src/entities/transfer.ts
+++ b/src/entities/transfer.ts
@@ -1,4 +1,4 @@
-import { Address, BigInt, store } from "@graphprotocol/graph-ts";
+import { Address, BigInt, Bytes, store } from "@graphprotocol/graph-ts";
 import { Transfer } from "../../generated/schema";
 import { BIG_INT_ZERO } from "../constants";
 
@@ -7,7 +7,8 @@ export function upsertTransfer(
   fromAddress: Address,
   toAddress: Address,
   quantity: BigInt,
-  timestamp: BigInt
+  timestamp: BigInt,
+  transactionHash: Bytes
 ): void {
   let transferId =
     nftId +
@@ -16,7 +17,7 @@ export function upsertTransfer(
     "_" +
     toAddress.toHexString() +
     "_" +
-    timestamp.toString();
+    transactionHash.toHexString();
   let transfer = Transfer.load(transferId);
 
   if (transfer == null) {
@@ -26,6 +27,7 @@ export function upsertTransfer(
     transfer.quantity = BIG_INT_ZERO;
     transfer.timestamp = timestamp;
     transfer.to = toAddress;
+    transfer.transactionHash = transactionHash;
   }
 
   let newQuantity = transfer.quantity.plus(quantity);

--- a/src/mappings/erc1155.ts
+++ b/src/mappings/erc1155.ts
@@ -13,7 +13,8 @@ export function handleTransferSingle(event: TransferSingle): void {
     event.params._to,
     event.params._id,
     event.params._value,
-    event.block.timestamp
+    event.block.timestamp,
+    event.transaction.hash
   );
 }
 
@@ -31,7 +32,8 @@ export function handleTransferBatch(event: TransferBatch): void {
       event.params._to,
       ids[i],
       values[i],
-      event.block.timestamp
+      event.block.timestamp,
+      event.transaction.hash
     );
   }
 }

--- a/src/mappings/erc721.ts
+++ b/src/mappings/erc721.ts
@@ -9,6 +9,7 @@ export function handleTransfer(event: Transfer): void {
     event.params.to,
     event.params.id,
     BIG_INT_ONE,
-    event.block.timestamp
+    event.block.timestamp,
+    event.transaction.hash
   );
 }


### PR DESCRIPTION
This PR adds two improvements:

- Integrates subgraph's [full text search field](https://thegraph.com/docs/en/developer/create-subgraph-hosted/#defining-fulltext-search-fields) feature to support `nftContract` search based on contract address, name, or symbol
- Adds `transactionHash` to the `Transfer` entity so we can provide a Snowtrace link on the frontend
<img width="908" alt="Screen Shot 2022-03-16 at 8 30 56 PM" src="https://user-images.githubusercontent.com/96929950/158713534-872e01da-3b1e-4725-8ab6-c5a44d48916d.png">

