### PR TITLE
Properly update NftContract's numOwners

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "ethereum-waffle": "^3.4.0",
     "ethereumjs-abi": "^0.6.8",
     "ethers": "^5.4.6",
-    "hardhat": "^2.6.4",
+    "hardhat": "^2.9.1",
     "hardhat-abi-exporter": "^2.3.0",
     "hardhat-contract-sizer": "^2.0.3",
     "hardhat-deploy": "^0.9.1",

--- a/schema.graphql
+++ b/schema.graphql
@@ -54,6 +54,14 @@ type Ownership @entity {
   quantity: BigInt!
 }
 
+type NftContractOwner @entity {
+  # {contractAddress}_{owner}
+  id: ID!
+  owner: Bytes!
+  contract: NftContract!
+  quantity: BigInt!
+}
+
 enum NftType {
   ERC721
   ERC1155

--- a/src/entities/nft.ts
+++ b/src/entities/nft.ts
@@ -104,12 +104,17 @@ export function transferBase(
 
     if (from != ZERO_ADDRESS_STRING) {
       // Is existing NFT
-      upsertOwnership(nftId, fromAddress, BIG_INT_ZERO.minus(value));
+      upsertOwnership(
+        nftContract,
+        nftId,
+        fromAddress,
+        BIG_INT_ZERO.minus(value)
+      );
     } // else minting
 
     if (to != ZERO_ADDRESS_STRING) {
       // Either a transfer or mint
-      upsertOwnership(nftId, toAddress, value);
+      upsertOwnership(nftContract, nftId, toAddress, value);
 
       // Always perform this check since the tokenURI can change over time
       if (nftContract.supportsMetadata) {

--- a/src/entities/nft.ts
+++ b/src/entities/nft.ts
@@ -145,33 +145,33 @@ export function transferBase(
         // Mint
         nftContract.numTokens = nftContract.numTokens.plus(BIG_INT_ONE);
       }
+
+      let toNftContractOwnerId = contractAddressHexString + "_" + to;
+      let toNftContractOwner = NftContractOwner.load(toNftContractOwnerId);
+      if (toNftContractOwner == null) {
+        toNftContractOwner = new NftContractOwner(toNftContractOwnerId);
+        toNftContractOwner.owner = toAddress;
+        toNftContractOwner.contract = contractAddressHexString;
+        toNftContractOwner.quantity = BIG_INT_ZERO;
+      }
+
+      // If `to` previously had 0 tokens from this NFT contract, increment
+      // the NFT contract's `numOwners` by one
+      if (
+        toNftContractOwner.quantity.equals(BIG_INT_ZERO) &&
+        value.gt(BIG_INT_ZERO)
+      ) {
+        nftContract.numOwners = nftContract.numOwners.plus(BIG_INT_ONE);
+      }
+
+      toNftContractOwner.quantity = toNftContractOwner.quantity.plus(value);
+      toNftContractOwner.save();
     } else {
       // Burn
       nft.burnedAt = timestamp;
       nftContract.numTokens = nftContract.numTokens.minus(BIG_INT_ONE);
     }
     nft.save();
-
-    let toNftContractOwnerId = contractAddressHexString + "_" + to;
-    let toNftContractOwner = NftContractOwner.load(toNftContractOwnerId);
-    if (toNftContractOwner == null) {
-      toNftContractOwner = new NftContractOwner(toNftContractOwnerId);
-      toNftContractOwner.owner = toAddress;
-      toNftContractOwner.contract = contractAddressHexString;
-      toNftContractOwner.quantity = BIG_INT_ZERO;
-    }
-
-    // If `to` previously had 0 tokens from this NFT contract, increment
-    // the NFT contract's `numOwners` by one
-    if (
-      toNftContractOwner.quantity.equals(BIG_INT_ZERO) &&
-      value.gt(BIG_INT_ZERO)
-    ) {
-      nftContract.numOwners = nftContract.numOwners.plus(BIG_INT_ONE);
-    }
-
-    toNftContractOwner.quantity = toNftContractOwner.quantity.plus(value);
-    toNftContractOwner.save();
 
     upsertTransfer(
       nftId,

--- a/src/entities/nft.ts
+++ b/src/entities/nft.ts
@@ -2,7 +2,7 @@ import { Address, BigInt, Bytes, store } from "@graphprotocol/graph-ts";
 import { ERC165 } from "../../generated/ERC721/ERC165";
 import { ERC721 } from "../../generated/ERC721/ERC721";
 import { ERC1155 } from "../../generated/ERC1155/ERC1155";
-import { Nft, NftContract } from "../../generated/schema";
+import { Nft, NftContract, NftContractOwner } from "../../generated/schema";
 import {
   BIG_INT_ONE,
   BIG_INT_ZERO,
@@ -104,17 +104,26 @@ export function transferBase(
 
     if (from != ZERO_ADDRESS_STRING) {
       // Is existing NFT
-      upsertOwnership(
-        nftContract,
-        nftId,
-        fromAddress,
-        BIG_INT_ZERO.minus(value)
+      upsertOwnership(nftId, fromAddress, BIG_INT_ZERO.minus(value));
+
+      let fromNftContractOwner = NftContractOwner.load(
+        contractAddressHexString + "_" + from
       );
+      if (fromNftContractOwner != null) {
+        // If `from` no longer has any tokens from this NFT contract, decrement
+        // the NFT contract's `numOwners` by one
+        if (value.ge(fromNftContractOwner.quantity)) {
+          nftContract.numOwners = nftContract.numOwners.minus(BIG_INT_ONE);
+        }
+        fromNftContractOwner.quantity =
+          fromNftContractOwner.quantity.minus(value);
+        fromNftContractOwner.save();
+      }
     } // else minting
 
     if (to != ZERO_ADDRESS_STRING) {
       // Either a transfer or mint
-      upsertOwnership(nftContract, nftId, toAddress, value);
+      upsertOwnership(nftId, toAddress, value);
 
       // Always perform this check since the tokenURI can change over time
       if (nftContract.supportsMetadata) {
@@ -142,6 +151,27 @@ export function transferBase(
       nftContract.numTokens = nftContract.numTokens.minus(BIG_INT_ONE);
     }
     nft.save();
+
+    let toNftContractOwnerId = contractAddressHexString + "_" + to;
+    let toNftContractOwner = NftContractOwner.load(toNftContractOwnerId);
+    if (toNftContractOwner == null) {
+      toNftContractOwner = new NftContractOwner(toNftContractOwnerId);
+      toNftContractOwner.owner = toAddress;
+      toNftContractOwner.contract = contractAddressHexString;
+      toNftContractOwner.quantity = BIG_INT_ZERO;
+    }
+
+    // If `to` previously had 0 tokens from this NFT contract, increment
+    // the NFT contract's `numOwners` by one
+    if (
+      toNftContractOwner.quantity.equals(BIG_INT_ZERO) &&
+      value.gt(BIG_INT_ZERO)
+    ) {
+      nftContract.numOwners = nftContract.numOwners.plus(BIG_INT_ONE);
+    }
+
+    toNftContractOwner.quantity = toNftContractOwner.quantity.plus(value);
+    toNftContractOwner.save();
 
     upsertTransfer(
       nftId,

--- a/src/entities/ownership.ts
+++ b/src/entities/ownership.ts
@@ -1,9 +1,8 @@
 import { Address, BigInt, store } from "@graphprotocol/graph-ts";
-import { NftContract, Ownership } from "../../generated/schema";
-import { BIG_INT_ONE, BIG_INT_ZERO } from "../constants";
+import { Ownership } from "../../generated/schema";
+import { BIG_INT_ZERO } from "../constants";
 
 export function upsertOwnership(
-  nftContract: NftContract,
   nftId: string,
   owner: Address,
   deltaQuantity: BigInt
@@ -16,10 +15,6 @@ export function upsertOwnership(
     ownership.nft = nftId;
     ownership.owner = owner;
     ownership.quantity = BIG_INT_ZERO;
-
-    if (deltaQuantity.gt(BIG_INT_ZERO)) {
-      nftContract.numOwners = nftContract.numOwners.plus(BIG_INT_ONE);
-    }
   }
 
   let newQuantity = ownership.quantity.plus(deltaQuantity);
@@ -27,8 +22,6 @@ export function upsertOwnership(
   // TODO: Should we throw error if newQuantity < 0?
   if (newQuantity.isZero() || newQuantity.lt(BIG_INT_ZERO)) {
     store.remove("Ownership", ownershipId);
-
-    nftContract.numOwners = nftContract.numOwners.minus(BIG_INT_ONE);
   } else {
     ownership.quantity = newQuantity;
     ownership.save();

--- a/yarn.lock
+++ b/yarn.lock
@@ -5930,7 +5930,7 @@ hardhat-watcher@^2.1.1:
   dependencies:
     chokidar "^3.4.3"
 
-hardhat@^2.6.4:
+hardhat@^2.9.1:
   version "2.9.1"
   resolved "https://registry.yarnpkg.com/hardhat/-/hardhat-2.9.1.tgz#f69f82bb4d98e28744584779483caa7c5cfbde8b"
   integrity sha512-q0AkYXV7R26RzyAkHGQRhhQjk508pseVvH3wSwZwwPUbvA+tjl0vMIrD4aFQDonRXkrnXX4+5KglozzjSd0//Q==


### PR DESCRIPTION
I noticed that I forgot to handle updating an `NftContract`'s `numOwners` field. This PR does it!